### PR TITLE
fixed the translation of free

### DIFF
--- a/index.lt.json
+++ b/index.lt.json
@@ -52,7 +52,7 @@
     "sect5_github": "Nori dalyvauti kurime? Mes jau esame <span class=\"text normal color white\">GitHub</span> tinklapyje.\n Programavimo patirtis yra nebūtina.",
     "sect5_sourceongithub": "Programos kodas GitHub tinklapyje",
     
-    "sect6_freesoftware": "Nemokama programinė įranga",
+    "sect6_freesoftware": "Laisva programinė įranga",
     "sect6_developers": "Mes esame patyrę žmonės iš <span class=\"text normal\">viso pasaulio</span>.",
     
     "sect6_jointheteam": "Prisijunk prie komandos",


### PR DESCRIPTION
There is a Lithuanian word for libre, but the guy here used free instead.
