### PR TITLE
Fixed blog URL

### DIFF
--- a/index.mustache
+++ b/index.mustache
@@ -126,7 +126,7 @@
 					&middot; <a href="https://github.com/irungentoo/ProjectTox-Core">GitHub</a><br>
 					&middot; <a href="https://jenkins.libtoxcore.so/">Jenkins</a><br>
 					&middot; <a href="https://libtoxcore.so/">{{{dev_docs}}}</a><br>
-					&middot; <a href="//blog.libtoxcore.so/">{{{dev_blog}}}</a><br>
+					&middot; <a href="//blog.tox.im/">{{{dev_blog}}}</a><br>
 				</div>
 				<div class="column_4 offset_1">
 					<p class="text bold big">{{{sect6_mailinglist_title}}}</p>


### PR DESCRIPTION
We should decide on using either schema-less URLs

``` html
<a href="//address">
```

or ones with schema

``` html
<a href="schema://address">
```
